### PR TITLE
Added Glossary

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -36,4 +36,8 @@ object Application extends Controller {
    * The ribbons page.
    */
   val ribbons = cached(views.html.ribbons())
+  /**
+   * The glossary page.
+   */
+  val glossary = cached(views.html.glossary())
 }

--- a/app/views/footer.scala.html
+++ b/app/views/footer.scala.html
@@ -1,5 +1,5 @@
 <footer>
-    The Reactive Manifesto.<br/>
+    <a href="/" >The Reactive Manifesto</a>.<br/>
     Show your support <a href="/ribbons">with a ribbon</a>.
 </footer>
 <a class="ribbon" href="/ribbons" style="right: 0; top:0; position: absolute;"><img src="/images/ribbons/we-are-reactive-blue-right.png"></a>

--- a/app/views/glossary.scala.html
+++ b/app/views/glossary.scala.html
@@ -1,0 +1,85 @@
+@main {
+    <main>
+        <header>
+            <a class="title-link" href="/"><h1>The <span>Reactive</span> Manifesto</h1></a>
+        </header>
+
+
+
+
+        <article>
+            <section id="glossary">
+                <h1>Glossary</h1>
+                <h2 id="Asynchronous">Asynchronous</h2>
+                <p>The Oxford Dictionary defines asynchronous as “not existing or occurring at the same time”. In the context of this manifesto we mean that the processing of a request occurs at an arbitrary point in time, sometime after it has been transmitted from client to service. The client cannot directly observe, or synchronize with, the execution that occurs within the service. This is the antonym of synchronous processing which implies that the client only resumes its own execution once the service has processed the request.</p>
+
+                <h2 id="Back-Pressure">Back-Pressure</h2>
+                <p>When one component is struggling to keep-up, the system as a whole needs to respond in a sensible way. It is unacceptable for the component under stress to fail catastrophically or to drop messages in an uncontrolled fashion. Since it can’t cope and it can’t fail it should communicate the fact that it is under stress to upstream components and so get them to reduce the load. This back-pressure is an important feedback mechanism that allows systems to gracefully respond to load rather than collapse under it. The back-pressure may cascade all the way up to the user, at which point responsiveness may degrade, but this mechanism will ensure that the system is resilient under load, and will provide information that may allow the system itself to apply other resources to help distribute the load, see Elasticity.</p>
+
+                <h2 id="Batching">Batching</h2>
+                <p>Current computers are optimized for the repeated execution of the same task: instruction caches and branch prediction increase the number of instructions that can be processed per second while keeping the clock frequency unchanged. This means that giving different tasks to the same CPU core in rapid succession will not benefit from the full performance that could otherwise be achieved: if possible we should structure the program such that its execution alternates less frequently between different tasks. This can mean processing a set of data elements in batches, or it can mean performing different processing steps on dedicated hardware threads.</p>
+                <p>The same reasoning applies to the use of external resources that need synchronization and coordination. The I/O bandwidth offered by persistent storage devices can improve dramatically when issuing commands from a single thread (and thereby CPU core) instead of contending for bandwidth from all cores. Using a single entry point has the added advantage that operations can be reordered to better suit the optimal access patterns of the device (current storage devices perform better for linear than random access).</p>
+                <p>Additionally, batching provides the opportunity to share out the cost of expensive operations such as I/O or expensive computations. For example, packing multiple data items into the same network packet or disk block to increase efficiency and reduce utilisation.</p>
+
+                <h2 id="Delegation">Delegation</h2>
+                <p>Delegating a task asynchronously to another component means that the execution of the task will take place in the context of that other component. This delegated context could entail running in a different error handling context, on a different thread, in a different process, or on a different network node, to name a few possibilities. The purpose of delegation is to hand over the processing responsibility of a task to another component so that the delegating component can perform other processing or optionally observe the progress of the delegated task in case additional action is required such as handling failure or reporting progress.</p>
+
+                <h2 id="Component">Component</h2>
+                <p>What we are describing is a modular software architecture, which is a very old idea, see for example <a href="https://www.cs.umd.edu/class/spring2003/cmsc838p/Design/criteria.pdf" target="_blank">Parnas (1972)</a>. We are using the term “component” due to its proximity with compartment, which implies that each component is self-contained, encapsulated and isolated from other components. This notion applies foremost to the runtime characteristics of the system, but it will typically also be reflected in the source code’s module structure as well. While different components might make use of the same software modules to perform common tasks, the program code that defines the top-level behavior of each component is then a module of its own. Component boundaries are often closely aligned with <a href="http://martinfowler.com/bliki/BoundedContext.html" target="_blank">Bounded Contexts</a> in the problem domain. This means that the system design tends to reflect the problem domain and so is easy to evolve, while retaining isolation. Message protocols provide a natural mapping and communications layer between Bounded Contexts (components).</p>
+
+                <h2 id="Elasticity">Elasticity (in contrast to Scalability)</h2>
+                <p>Elasticity means that the throughput of a system scales up or down automatically to meet varying demand as resource is proportionally added or removed. The system needs to be scalable (see Scalability) to allow it to benefit from the dynamic addition, or removal, of resources at runtime. Elasticity therefore builds upon scalability and expands on it by adding the notion of automatic resource management.</p>
+
+                <h2 id="Failure">Failure (in contrast to Error)</h2>
+                <p>A failure is an unexpected event within a service that prevents it from continuing to function normally. A failure will generally prevent responses to the current, and possibly all following, client requests. This is in contrast with an error, which is an expected and coded-for condition—for example an error discovered during input validation, that will be communicated to the client as part of the normal processing of the message. Failures are unexpected and will require intervention before the system can resume at the same level of operation. This does not mean that failures are always fatal, rather that some capacity of the system will be reduced following a failure. Errors are an expected part of normal operations, are dealt with immediately and the system will continue to operate at the same capacity following an error.</p>
+                <p>Examples of failures are hardware malfunction, processes terminating due to fatal resource exhaustion, program defects that result in corrupted internal state.</p>
+
+                <h2 id="Isolation">Isolation (and Containment)</h2>
+                <p>Isolation can be defined in terms of decoupling, both in time and space. Decoupling in time means that the sender and receiver can have independent life-cycles—they do not need to be present at the same time for communication to be possible. It is enabled by adding asynchronous boundaries between the components, communicating through message-passing. Decoupling in space (defined as Location Transparency) means that the sender and receiver do not have to run in the same process, but wherever the operations division or the runtime itself decides is most efficient—which might change during an application's lifetime. </p>
+                <p>True isolation goes beyond the notion of encapsulation found in most object-oriented languages and gives us compartmentalization and containment of:</p>
+                <ul>
+                    <li>State and behavior: it enables share-nothing designs and minimizes contention and coherence cost (as defined in the <a href="http://www.perfdynamics.com/Manifesto/USLscalability.html" target="_blank"> Universal Scalability Law</a>); </li>
+                    <li>Failures: it allows errors to be captured, signalled and managed at a fine-grained level instead of letting them cascade to other components.</li>
+                </ul>
+                <p>Strong isolation between components is built on communication over well-defined protocols and enables loose coupling, leading to systems that are easier to understand, extend, test and evolve.</p>
+
+                <h2 id="Location-Transparency">Location Transparency</h2>
+                <p>Elastic systems needs to be adaptive and continuously react to changes in demand, they need to gracefully and efficiently increase and decrease scale. One key insight that simplifies this problem immensely is to realize that we are all doing distributed computing. This is true whether we are running our systems on a single node (with multiple independent CPUs communicating over the QPI link) or on a cluster of nodes (with independent machines communicating over the network). Embracing this fact means that there is no conceptual difference between scaling vertically on multicore or horizontally on the cluster.</p>
+                <p>If all of our components support mobility, and local communication is just an optimization, then we do not have to define a static system topology and deployment model upfront. We can leave this decision to the operations personnel and the runtime, which can adapt and optimize the system depending on how it is used.</p>
+                <p>This decoupling in space (see the the definition for Isolation), enabled through asynchronous message-passing, and decoupling of the runtime instances from their references is what we call Location Transparency. Location Transparency is often mistaken for 'transparent distributed computing', while it is actually the opposite: we embrace the network and all its constraints—like partial failure, network splits, dropped messages, and its asynchronous and message-based nature—by making them first class in the programming model, instead of trying to emulate in-process method dispatch on the network (ala RPC, XA etc.). Our view of Location Transparency is in perfect agreement with <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.41.7628" target="_blank"> A Note On Distributed Computing</a> by Waldo et al.</p>
+
+                <h2 id="Message-Driven">Message-Driven (in contrast to Event-Driven)</h2>
+                <p>A message is an item of data that is sent to a specific destination. An event is a signal emitted by a component upon reaching a given state. In a message-driven system addressable recipients await the arrival of messages and react to them, otherwise lying dormant. In an event-driven system notification listeners are attached to the sources of events such that they are invoked when the event is emitted. This means that an event-driven system focuses on addressable event sources while a message-driven system concentrates on addressable recipients. A message can contain an encoded event as its payload.</p>
+                <p>Resilience is more difficult to achieve in an event-driven system due to the short-lived nature of event consumption chains: when processing is set in motion and listeners are attached in order to react to and transform the result, these listeners typically handle success or failure directly and in the sense of reporting back to the original client. Responding to the failure of a component in order to restore its proper function, on the other hand, requires a treatment of these failures that is not tied to ephemeral client requests, but that responds to the overall component health state.</p>
+
+                <h2 id="Non-Blocking">Non-Blocking</h2>
+                <p>In concurrent programming an algorithm is considered non-blocking if threads competing for a resource do not have their execution indefinitely postponed by mutual exclusion protecting that resource. In practice this usually manifests as an API that allows access to the resource if it is available otherwise it immediately returns informing the caller that the resource is not currently available or that the operation has been initiated and not yet completed. A non-blocking API to a resource allows the caller the option to do other work rather than be blocked waiting on the resource to become available. This may be complemented by allowing the client of the resource to register for getting notified when the resource is available or the operation has completed.</p>
+
+                <h2 id="Protocol">Protocol</h2>
+                <p>A protocol defines the treatment and etiquette for the exchange or transmission of messages between components. Protocols are formulated as relations between the participants to the exchange, the accumulated state of the protocol and the allowed set of messages to be sent. This means that a protocol describes which messages a participant may send to another participant at any given point in time. Protocols can be classified by the shape of the exchange, some common classes are request–reply, repeated request–reply (as in HTTP), publish–subscribe, and stream (both push and pull).</p>
+                <p>In comparison to local programming interfaces a protocol is more generic since it can include more than two participants and it foresees a progression of the state of the message exchange; an interface only specifies one interaction at a time between the caller and the receiver.</p>
+                <p>It should be noted that a protocol as defined here just specifies which messages may be sent, but not how they are sent: encoding, decoding (i.e. codecs), and transport mechanisms are implementation details that are transparent to the components’ use of the protocol.</p>
+
+                <h2 id="Replication">Replication</h2>
+                <p>Executing a component simultaneously in different places is referred to as replication. This can mean executing on different threads or thread pools, processes, network nodes, or computing centers. Replication offers scalability, where the incoming workload is distributed across multiple instances of a component, or resilience, where the incoming workload is replicated to multiple instances which process the same requests in parallel. These approaches can be mixed, for example by ensuring that all transactions pertaining to a certain user of the component will be executed by two instances while the total number of instances varies with the incoming load, (see Elasticity).</p>
+
+                <h2 id="Resource">Resource</h2>
+                <p>Everything that a component relies upon to perform its function is a resource that must be provisioned according to the component’s needs. This includes CPU allocation, main memory and persistent storage as well as network bandwidth, main memory bandwidth, CPU caches, inter-socket CPU links, reliable timer and task scheduling services, other input and output devices, external services like databases or network file systems etc. The elasticity and resilience of all these resources must be considered, since the lack of a required resource will prevent the component from functioning when required.</p>
+
+                <h2 id="Scalability">Scalability</h2>
+                <p>The ability of a system to make use of more computing resources in order to increase its performance is measured by the ratio of throughput gain to resource increase. A perfectly scalable system is characterized by both both numbers being proportional: a twofold allocation of resources will double the throughput. Scalability is typically limited by the introduction of bottlenecks or synchronization points within the system, leading to constrained scalability, see <a href="http://blogs.msdn.com/b/ddperf/archive/2009/04/29/parallel-scalability-isn-t-child-s-play-part-2-amdahl-s-law-vs-gunther-s-law.aspx" target="_blank"> Amdahl’s Law and Gunther’s Universal Scalability Model</a>.</p>
+
+                <h2 id="System">System</h2>
+                <p>A system provides services to its users or clients. Systems can be large or small, in which case they comprise many or just a few components. All components of a system collaborate to provide these services. In many cases the components are in a client–server relationship within the same system (consider for example front-end components relying upon back-end components). A system shares a common resilience model, by which we mean that failure of a component is handled within the system, delegated from one component to the other. It is useful to view groups of components within a system as subsystems if they are isolated from the rest of the system in their function, resources or failure modes.</p>
+
+                <h2 id="User">User</h2>
+                <p>We use this term informally to refer to any consumer of a service, be that a human or another service.</p>
+
+                <a href="#glossary" class="btt">&#8593; BACK TO TOP</a>
+
+
+            </section>
+        </article>
+        @footer()
+    </main>
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -86,6 +86,10 @@
                     <div class="g-plus" data-action="share" data-annotation="bubble" data-href="http://reactivemanifesto.org"></div>
                     <script type="IN/Share" data-url="http://reactivemanifesto.org" data-counter="right"></script>
                 <p>
+                    <a class="" href="/glossary">Glossary</a>
+                </p>
+
+                <p>
                     <a class="pdf" href="@routes.Assets.at("pdf/the-reactive-manifesto-2.0.pdf")">Download as PDF</a>
                 </p>
                 <p>

--- a/conf/routes
+++ b/conf/routes
@@ -3,6 +3,7 @@
 # ~~~~
 
 GET           /                         controllers.Application.index
+GET           /glossary                 controllers.Application.glossary
 GET           /list                     controllers.Application.list
 GET           /ribbons                  controllers.Application.ribbons
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -32,12 +32,49 @@ h1 {
 h1 span {
   border-bottom: 2px solid #445de9;
 }
+
+header a  {
+    text-decoration: none;
+}
+
 h2 {
   font-weight: 100;
   font-size: 50px;
   margin: 1em 0 .3em 0;
   color: #445de9;
 }
+
+
+#glossary h1 {
+  font-size: 40px;
+  margin: 1em 0  0.5em;
+}
+
+#glossary h2 {
+  font-size: 20px;
+  font-weight: normal;
+  margin: 2em 0 0 0;
+}
+#glossary h2 + p {
+  margin-top: 0;
+}
+
+.btt {
+  text-decoration: none;
+  font-size: 12px;
+  color: white;
+  background: #445de9;
+  padding: 5px 10px;
+  font-weight: normal;
+  font-family: "Helvetica Neue", sans-serif;
+
+}
+
+.btt:hover {
+  color: white;
+  text-decoration: underline;
+}
+
 @media screen and (max-width: 960px) {
   h2 {
     font-size: 2em;


### PR DESCRIPTION
@jboner Glossary has been built out. Please ignore the branch name - I called it appendix by mistake!  

The main title 'The Reactive Manifesto' on the glossary page links back to the homepage. I've also made the footer link back as well. Each term in the glossary has an HTML ID associated with it, so that it's easy to build links such as /glossary#Location-Transparency that anchor down to the actual term. 

![glossary](https://cloud.githubusercontent.com/assets/1418129/4638273/22ddb3f6-53f8-11e4-8b3f-385cb2c5bc68.png)
