### PR TITLE
Update to new Cookie Compliance, add links to principle website

### DIFF
--- a/app/views/footer.scala.html
+++ b/app/views/footer.scala.html
@@ -1,24 +1,37 @@
 @(implicit messages: MessagesApi, lang: Lang, assetsFinder: AssetsFinder)
 <footer>
-    <a href="@routes.Application.index("en")">@messages("title")(Lang("en"))</a> (@messages("footer.english")) <br/>
-    <a href="@routes.Application.index("es")" >@messages("title")(Lang("es"))</a> (@messages("footer.spanish")) <br/>
-    <a href="@routes.Application.index("ja")" >@messages("title")(Lang("ja"))</a> (@messages("footer.japanese")) <br/>
-    <a href="@routes.Application.index("de")" >@messages("title")(Lang("de"))</a> (@messages("footer.german")) <br/>
-    <a href="@routes.Application.index("fr")" >@messages("title")(Lang("fr"))</a> (@messages("footer.french")) <br/>
-    <a href="@routes.Application.index("it")" >@messages("title")(Lang("it"))</a> (@messages("footer.italian")) <br/>
-    <a href="@routes.Application.index("pt")" >@messages("title")(Lang("pt"))</a> (@messages("footer.portuguese")) <br/>
-    <a href="@routes.Application.index("pt-BR")" >@messages("title")(Lang("pt-BR"))</a> (@messages("footer.portugueseBrazilian")) <br/>
-    <a href="@routes.Application.index("tr")" >@messages("title")(Lang("tr"))</a> (@messages("footer.turkish")) <br/>
-    <a href="@routes.Application.index("id")" >@messages("title")(Lang("id"))</a> (@messages("footer.indonesia")) <br/>
-    <a href="@routes.Application.index("zh-CN")" >@messages("title")(Lang("zh-CN"))</a> (@messages("footer.simpleChinese")) <br/>
-    <a href="@routes.Application.index("ko")" >@messages("title")(Lang("ko"))</a> (@messages("footer.korean")) <br/>
-    <a href="@routes.Application.index("fa")" >@messages("title")(Lang("fa"))</a> (@messages("footer.farsi")) <br/>
-    <a href="@routes.Application.index("sw")" >@messages("title")(Lang("sw"))</a> (@messages("footer.swahili")) <br/>
-    <a href="@routes.Application.index("cz")" >@messages("title")(Lang("cz"))</a> (@messages("footer.czech")) <br/>
-    <a href="@routes.Application.index("ru")" >@messages("title")(Lang("ru"))</a> (@messages("footer.russian")) <br/>
+    <a href="@routes.Application.index(" en")">@messages("title")(Lang("en"))</a> (@messages("footer.english")) <br />
+    <a href="@routes.Application.index(" es")">@messages("title")(Lang("es"))</a> (@messages("footer.spanish")) <br />
+    <a href="@routes.Application.index(" ja")">@messages("title")(Lang("ja"))</a> (@messages("footer.japanese")) <br />
+    <a href="@routes.Application.index(" de")">@messages("title")(Lang("de"))</a> (@messages("footer.german")) <br />
+    <a href="@routes.Application.index(" fr")">@messages("title")(Lang("fr"))</a> (@messages("footer.french")) <br />
+    <a href="@routes.Application.index(" it")">@messages("title")(Lang("it"))</a> (@messages("footer.italian")) <br />
+    <a href="@routes.Application.index(" pt")">@messages("title")(Lang("pt"))</a> (@messages("footer.portuguese"))
+    <br />
+    <a href="@routes.Application.index(" pt-BR")">@messages("title")(Lang("pt-BR"))</a>
+    (@messages("footer.portugueseBrazilian")) <br />
+    <a href="@routes.Application.index(" tr")">@messages("title")(Lang("tr"))</a> (@messages("footer.turkish")) <br />
+    <a href="@routes.Application.index(" id")">@messages("title")(Lang("id"))</a> (@messages("footer.indonesia")) <br />
+    <a href="@routes.Application.index(" zh-CN")">@messages("title")(Lang("zh-CN"))</a>
+    (@messages("footer.simpleChinese")) <br />
+    <a href="@routes.Application.index(" ko")">@messages("title")(Lang("ko"))</a> (@messages("footer.korean")) <br />
+    <a href="@routes.Application.index(" fa")">@messages("title")(Lang("fa"))</a> (@messages("footer.farsi")) <br />
+    <a href="@routes.Application.index(" sw")">@messages("title")(Lang("sw"))</a> (@messages("footer.swahili")) <br />
+    <a href="@routes.Application.index(" cz")">@messages("title")(Lang("cz"))</a> (@messages("footer.czech")) <br />
+    <a href="@routes.Application.index(" ru")">@messages("title")(Lang("ru"))</a> (@messages("footer.russian")) <br />
     <br>
+    <div class="companion-wrapper">
+
+        <p class="companion">
+            <a class="r-logo white" href="https://www.reactivemanifesto.org/">The <span>Reactive</span> Manifesto</a>
+            <em>a
+                companion to</em>
+            <a class="r-logo white" href="https://www.reactiveprinciples.org">The <span>Reactive</span> Principles</a>
+        </p>
+    </div>
     <p>@Html(messages("footer.ribbonSupport", "<a href='" + routes.Application.ribbons(lang.code) + "'>", "</a>"))</p>
     <p class="copyright">&copy; @messages("footer.copyright")</p>
-    <p class="legal-links"><small><a href='/privacy'>Privacy Policy</a> | <a href="/cookie">Cookie Policy</a> | <a class="optanon-toggle-display">Cookie Settings</a></small></p>
+    <p class="legal-links"><small><a href='/privacy'>Privacy Policy</a> | <a href="/cookie">Cookie Policy</a> | <a
+                id="ot-sdk-btn" class="ot-sdk-show-settings">Cookie Settings</a></small></p>
 </footer>
-<a class="ribbon" href="@routes.Application.ribbons(lang.code)" style="right: 0; top:0; position: absolute;"><img src="@assetsFinder.path("images/ribbons/we-are-reactive-blue-right.png")"></a>
+<a class="ribbon" href="@routes.Application.ribbons(lang.code)" style="right: 0; top:0; position: absolute;"><img src='@assetsFinder.path("images/ribbons/we-are-reactive-blue-right.png")'></a>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -102,7 +102,11 @@
                 </p>
                 <p>
                 <a class="pdf" href="https://github.com/reactivemanifesto/reactivemanifesto/blob/master/README@{Option(lang.code).filterNot(_ == "en").fold("")("." + _)}.md">@messages("manifesto.suggestImprovements")</a>
-                </p><br />
+                </p>
+                <p>
+                    <a href="https://www.reactiveprinciples.org">@messages("principles.cta")</a>
+                </p>
+                <br />
                 <p><strong>Authors</strong> (in alphabetic order, with roughly equal contributions):<br /> Jonas Bonér, Dave Farley, Roland Kuhn, and Martin Thompson. With the help and refinement of many members in the community.</p>
         </article>
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -9,7 +9,7 @@
 		<link rel="shortcut icon" href="@assetsFinder.path("images/favicon.ico")" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 		<!-- OneTrust Cookies Consent Notice (Production Standard, reactivemanifesto.org, en-GB) start -->
-		<script src="https://optanon.blob.core.windows.net/consent/6b6fabc7-9d0c-4c69-94aa-bf764de77319.js" type="text/javascript" charset="UTF-8"></script>
+		<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="93a21acc-3009-46bb-8edb-88a1df1243bc"></script>
 		<script type="text/javascript">
 			function OptanonWrapper() {
 				@optanonInsert
@@ -24,15 +24,16 @@
 		@content
 
 		<script src="@assetsFinder.path("lib/retinajs/retina.js")" type="text/javascript"></script>
-		<script type="text/plain" class="optanon-category-2">
-			var _gaq = _gaq || [];
-			_gaq.push(['_setAccount', 'UA-42352555-1']);
-			_gaq.push(['_trackPageview']);
-			(function() {
-			var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-			ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-			})();
+		<!-- Google Tag Manager - Used to load GA4 Analytics - cookie compliance is managed inside tag manager  -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+			'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+			})(window,document,'script','dataLayer','GTM-NKW8QMN');
 		</script>
+		<!-- End Google Tag Manager -->
+
+		<!-- NOTE Old Universal Google Anayltics UA-42352555-1 is now handled by Tag Manager above -->
+
 	</body>
 </html>

--- a/conf/messages
+++ b/conf/messages
@@ -17,6 +17,9 @@ manifesto.publishVersion = Published on September 16 2014. (v2.0)
 manifesto.downloadAsPDF = Download as PDF
 manifesto.suggestImprovements = Suggest improvements
 
+#Principle
+principles.cta = Read the Reactive Principles
+
 # List
 list.title = Signatures
 list.loading = Loading...

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -844,21 +844,47 @@ figure figcaption:before {
   }
 }
 
-
-body .optanon-alert-box-wrapper .optanon-alert-box-bottom-top {
-    height: 20px
-}
-body .optanon-alert-box-wrapper .optanon-alert-box-bottom-padding {
-    padding-bottom: 20px
-}
-.optanon-cookie-policy-group-name {
-    font-weight: 700
-}
-.optanon-toggle-display {
+.ot-sdk-show-settings {
   cursor: pointer;
+  border: none !important;
+  padding: 0 !important;
 }
+.ot-sdk-show-settings:hover {
+  background-color: transparent !important;
+}
+
 .legal-links a {
   font-size: .75rem;
   text-transform: uppercase;
   opacity: .7
+}
+
+.companion {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem 0;
+
+}
+
+.companion .r-logo {
+  font-size: 1.5rem;
+  margin: 0;
+  font-weight: 200;
+  font-family: "Helvetica Neue", sans-serif;
+  text-decoration: none;
+  line-height: 1.3;
+}
+.companion .r-logo span {
+  border-bottom: 2px solid #fff;
+}
+.companion .r-logo:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+.companion em {
+  opacity: 0.7;
 }


### PR DESCRIPTION
This updates the manifesto to the latest cookie compliance, as well as adds links to the Reactive Principle which is now branded as a Manifesto companion piece. 

@sebastian-alfers not quite sure how to deploy this? Will it auto deploy if merged?